### PR TITLE
Add Flutter booking app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# codexdemo
+# Teco Group Booking
+
+Aplicación móvil desarrollada en Flutter que permite a los colaboradores de Teco Group reservar espacios físicos como aulas, salas de reuniones y salones Scrum.
+
+## Requisitos
+- Flutter SDK
+
+## Ejecución
+
+1. Instalar dependencias:
+   ```bash
+   flutter pub get
+   ```
+2. Ejecutar la aplicación:
+   ```bash
+   flutter run
+   ```
+
+Este proyecto es un punto de partida e incluye un flujo básico de inicio de sesión, selección de espacios, creación de reservas e historial.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'models/booking_provider.dart';
+import 'screens/login_screen.dart';
+import 'screens/home_screen.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => BookingProvider(),
+      child: MaterialApp(
+        title: 'Teco Group Booking',
+        theme: ThemeData(primarySwatch: Colors.blue),
+        routes: {
+          '/': (_) => const LoginScreen(),
+          '/home': (_) => const HomeScreen(),
+        },
+      ),
+    );
+  }
+}

--- a/lib/models/booking.dart
+++ b/lib/models/booking.dart
@@ -1,0 +1,21 @@
+import 'space.dart';
+
+class Booking {
+  final Space space;
+  final DateTime start;
+  final DateTime end;
+  final int participants;
+  final String activity;
+  final List<String> equipment;
+  final List<String> invitees;
+
+  Booking({
+    required this.space,
+    required this.start,
+    required this.end,
+    required this.participants,
+    required this.activity,
+    required this.equipment,
+    required this.invitees,
+  });
+}

--- a/lib/models/booking_provider.dart
+++ b/lib/models/booking_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/foundation.dart';
+
+import 'booking.dart';
+
+class BookingProvider with ChangeNotifier {
+  final List<Booking> _bookings = [];
+
+  List<Booking> get bookings => List.unmodifiable(_bookings);
+
+  void addBooking(Booking booking) {
+    _bookings.add(booking);
+    notifyListeners();
+  }
+}

--- a/lib/models/sample_data.dart
+++ b/lib/models/sample_data.dart
@@ -1,0 +1,10 @@
+import 'space.dart';
+
+const spaces = [
+  Space(id: 'class1', name: 'Salon de clase 1', capacity: 20),
+  Space(id: 'class2', name: 'Salon de clase 2', capacity: 20),
+  Space(id: 'scrum1', name: 'Salon Scrum 1', capacity: 10),
+  Space(id: 'scrum2', name: 'Salon Scrum 2', capacity: 10),
+  Space(id: 'pecera', name: 'La Pecera', capacity: 10),
+  Space(id: 'nevera', name: 'La Nevera', capacity: 20),
+];

--- a/lib/models/space.dart
+++ b/lib/models/space.dart
@@ -1,0 +1,7 @@
+class Space {
+  final String id;
+  final String name;
+  final int capacity;
+
+  const Space({required this.id, required this.name, required this.capacity});
+}

--- a/lib/screens/booking_form_screen.dart
+++ b/lib/screens/booking_form_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/booking.dart';
+import '../models/booking_provider.dart';
+import '../models/space.dart';
+
+class BookingFormScreen extends StatefulWidget {
+  final Space space;
+
+  const BookingFormScreen({super.key, required this.space});
+
+  @override
+  State<BookingFormScreen> createState() => _BookingFormScreenState();
+}
+
+class _BookingFormScreenState extends State<BookingFormScreen> {
+  final _formKey = GlobalKey<FormState>();
+  DateTime _start = DateTime.now();
+  DateTime _end = DateTime.now().add(const Duration(hours: 1));
+  int _participants = 1;
+  String _activity = '';
+  final List<String> _equipment = [];
+  final List<String> _invitees = [];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Reservar ${widget.space.name}')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Actividad'),
+                onSaved: (v) => _activity = v ?? '',
+              ),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Número de personas'),
+                keyboardType: TextInputType.number,
+                initialValue: '1',
+                onSaved: (v) => _participants = int.tryParse(v ?? '1') ?? 1,
+              ),
+              ElevatedButton(
+                onPressed: _submit,
+                child: const Text('Confirmar'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _submit() {
+    _formKey.currentState?.save();
+    final booking = Booking(
+      space: widget.space,
+      start: _start,
+      end: _end,
+      participants: _participants,
+      activity: _activity,
+      equipment: _equipment,
+      invitees: _invitees,
+    );
+    Provider.of<BookingProvider>(context, listen: false).addBooking(booking);
+    Navigator.pop(context);
+  }
+}

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/booking_provider.dart';
+
+class HistoryScreen extends StatelessWidget {
+  const HistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final bookings = Provider.of<BookingProvider>(context).bookings;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Historial de Reservas')),
+      body: ListView.builder(
+        itemCount: bookings.length,
+        itemBuilder: (context, index) {
+          final booking = bookings[index];
+          return ListTile(
+            title: Text(booking.space.name),
+            subtitle: Text('${booking.start} - ${booking.end}'),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/booking_provider.dart';
+import '../models/sample_data.dart';
+import 'booking_form_screen.dart';
+import 'history_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final bookingProvider = Provider.of<BookingProvider>(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Espacios Disponibles'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.history),
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const HistoryScreen()),
+            ),
+          ),
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: spaces.length,
+        itemBuilder: (context, index) {
+          final space = spaces[index];
+          return ListTile(
+            title: Text(space.name),
+            subtitle: Text('Capacidad: ${space.capacity} personas'),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => BookingFormScreen(space: space),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Center(
+        child: ElevatedButton(
+          child: const Text('Ingresar'),
+          onPressed: () => Navigator.pushReplacementNamed(context, '/home'),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,18 @@
+name: teco_group_booking
+version: 0.1.0
+publish_to: 'none'
+description: App de Agendamiento de Espacios para Teco Group
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  provider: ^6.0.0
+
+  # Agregar dependencias para Firebase o Supabase según se requiera
+  # firebase_core: ^2.0.0
+  # supabase_flutter: ^1.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add pubspec with provider dep
- implement booking models and provider
- create screens for login, home, booking form, and history
- add basic Flutter app wiring
- update README with setup instructions

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8ee5f1ec832eb3429a4ffa04c096